### PR TITLE
Refactroing

### DIFF
--- a/app/data/config.py
+++ b/app/data/config.py
@@ -13,3 +13,10 @@ WEBAPP_PORT = os.environ['WEBAPP_PORT']
 
 WEBHOOK_SSL_CERT = './webhook_cert.pem'
 WEBHOOK_SSL_PRIV = './webhook_pkey.pem'
+
+MONGO_USER = os.environ['MONGO_USER']
+MONGO_PASSWORD = os.environ['MONGO_PASSWORD']
+MONGO_HOST = os.environ['MONGO_HOST']
+MONGO_PORT = os.environ['MONGO_PORT']
+MONGO_RECIPE_DB_NAME = os.environ['MONGO_RECIPE_DB']
+MONGO_URI = f'mongodb://{MONGO_USER}:{MONGO_PASSWORD}@{MONGO_HOST}:{MONGO_PORT}'

--- a/app/data/messages_text.py
+++ b/app/data/messages_text.py
@@ -1,0 +1,24 @@
+WELCOME_MESSAGE = 'Привет!\n' \
+                  'Бот работает как мешок, в который можно поместить записки,' \
+                  ' перемешать и вытащить случайную.\n' \
+                  'Для себя я использую бота как мешок с блюдами. Когда' \
+                  ' не могу выбрать, что поесть - беру наугад.\n' \
+                  'Значок \U0001F373 означает, что обьект уже использован.\n' \
+                  'С проблемами и пожалениями обращайтесь к @kekusmekus.'
+
+EMPTY_RECIPES_LIST_MESSAGE = 'Список рецептов пуст. Чтобы добавить рецепт отправьте "/add"'
+SHOWN_RECIPES_MESSAGE = 'Список рецептов:'
+WRITE_RECIPE_NAME_MESSAGE = 'Напишите название рецепта'
+ADDED_RECIPE_MESSAGE = 'Добавлен рецепт\n'
+SINGLE_SHOWN_RECIPE_MESSAGE = 'Рецепт:\n'
+ALL_RECIPES_MARKED_AS_UNUSED_MESSAGE = 'Все рецепты помечены как неиспользованные.'
+
+ERROR_THERE_IS_NO_RECIPE_CALLBACK_MESSAGE = 'Ошибка! Рецепт отсутствует.'
+RECIPE_DELETED_MESSAGE = 'Рецепт удален.'
+
+MARK_AS_UNUSED_RECIPE_BUTTON_TEXT = 'Пометить как неиспользованный'
+MARK_AS_USED_RECIPE_BUTTON_TEXT = 'Использовать рецепт'
+DELETE_RECIPE_BUTTON_TEXT = 'Удалить'
+
+IS_USED_RECIPE_DETAILS_MESSAGE = 'Статус: Использован \U0001F373'
+IS_UNUSED_RECIPE_DETAILS_MESSAGE = 'Статус: Неиспользован'

--- a/app/db.py
+++ b/app/db.py
@@ -2,14 +2,13 @@ import os
 import random
 
 from bson.objectid import ObjectId
-from motor.motor_asyncio import (AsyncIOMotorClient, AsyncIOMotorCollection,
-                                 AsyncIOMotorDatabase)
+from motor.motor_asyncio import AsyncIOMotorCollection
 from pymongo.collection import ReturnDocument
 
 from app.exceptions import UserHasNoRecipesError, UserHasNoSelectedRecipeError
 from app.recipe_shema import Recipe, RecipeWithId
 from app.constants import MAXIMUM_COUNT_OF_RETURNED_RECIPES
-from loader import db
+from loader import db_connection
 
 
 def _dispatch_user_id(user_id: int) -> AsyncIOMotorCollection:
@@ -22,7 +21,7 @@ def _dispatch_user_id(user_id: int) -> AsyncIOMotorCollection:
         AsyncIOMotorCollection: user Mongo collection.
     """
     user_id = str(user_id)
-    return db[user_id]
+    return db_connection[user_id]
 
 
 async def add_recipe_by_name(user_id: int, recipe_name: str) -> None:

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -1,0 +1,5 @@
+from app.handlers.callback_query_handlers import dp
+from app.handlers.message_handlers import dp
+
+
+__all__ = ['dp']

--- a/app/handlers/callback_query_handlers.py
+++ b/app/handlers/callback_query_handlers.py
@@ -1,0 +1,99 @@
+from functools import partial
+
+from aiogram.types import ParseMode
+
+from app import db
+from app.callback_data_schema import (DeleteRecipeCallbackData,
+                                      RecipeDetailsCallbackData,
+                                      UnuseRecipeCallbackData,
+                                      UseRecipeCallbackData,
+                                      is_valid_schema_for_callback)
+
+from app.exceptions import UserHasNoSelectedRecipeError
+from app.keyboards.layouts import create_recipe_details_layout
+from app.data.messages_text import ERROR_THERE_IS_NO_RECIPE_CALLBACK_MESSAGE, RECIPE_DELETED_MESSAGE
+from loader import dp, bot, logger
+
+
+@dp.callback_query_handler(partial(is_valid_schema_for_callback, schema=RecipeDetailsCallbackData))
+async def show_recipe_details(callback_query):
+    recipe_callback_data = RecipeDetailsCallbackData.parse_raw(callback_query.data)
+    # TODO: (1) (this is how identical fragments are marked)
+    # I don't know how to abstract this block.
+    # I don't want to check if recipe is exists each time.
+    # Because of performance and and that this situation is really an error.
+    # And I think return None by db method is bad idea because of poorly
+    # controlled behavior.
+    # If you know good resolution for this situation, please
+    # write an issue or do a pull request.
+    try:
+        recipe = await db.find_recipe_by_id(callback_query.from_user.id,
+                                            recipe_callback_data.id)
+    except UserHasNoSelectedRecipeError:
+        logger.exception(
+            f"user {callback_query.from_user.id} clicked on already"
+            "deleted recipe with id {recipe_callback_data.id}"
+            )
+        await callback_query.answer(text=ERROR_THERE_IS_NO_RECIPE_CALLBACK_MESSAGE)
+        await callback_query.message.delete()
+    else:
+        recipe_details_layout = create_recipe_details_layout(recipe)
+        await bot.edit_message_text(chat_id=callback_query.from_user.id,
+                                    message_id=callback_query.message.message_id,
+                                    **recipe_details_layout)
+
+
+@dp.callback_query_handler(partial(is_valid_schema_for_callback, schema=UseRecipeCallbackData))
+async def use_recipe(callback_query):
+    recipe_callback_data = UseRecipeCallbackData.parse_raw(callback_query.data)
+    recipe_id = recipe_callback_data.id
+    # TODO: (1)
+    try:
+        recipe = await db.take_recipe_by_id(callback_query.from_user.id, recipe_id)
+    except UserHasNoSelectedRecipeError:
+        logger.exception(
+            f"user {callback_query.from_user.id} clicked on already"
+            "deleted recipe with id {recipe_callback_data.id}"
+            )
+        await callback_query.answer(text=ERROR_THERE_IS_NO_RECIPE_CALLBACK_MESSAGE)
+        await callback_query.message.delete()
+    else:
+        recipe_details_layout = create_recipe_details_layout(recipe)
+        await bot.edit_message_text(chat_id=callback_query.from_user.id,
+                                    message_id=callback_query.message.message_id,
+                                    inline_message_id=callback_query.inline_message_id,
+                                    **recipe_details_layout)
+
+
+@dp.callback_query_handler(partial(is_valid_schema_for_callback, schema=UnuseRecipeCallbackData))
+async def unuse_recipe(callback_query):
+    recipe_callback_data = UnuseRecipeCallbackData.parse_raw(callback_query.data)
+    recipe_id = recipe_callback_data.id
+    # TODO: (1)
+    try:
+        recipe = await db.unuse_and_find_recipe_by_id(callback_query.from_user.id, recipe_id)
+    except UserHasNoSelectedRecipeError:
+        logger.exception(
+            f"user {callback_query.from_user.id} clicked on already"
+            "deleted recipe with id {recipe_callback_data.id}"
+            )
+        await callback_query.answer(text=ERROR_THERE_IS_NO_RECIPE_CALLBACK_MESSAGE)
+        await callback_query.message.delete()
+    else:
+        recipe_details_layout = create_recipe_details_layout(recipe)
+        await bot.edit_message_text(chat_id=callback_query.from_user.id,
+                                    message_id=callback_query.message.message_id,
+                                    inline_message_id=callback_query.inline_message_id,
+                                    **recipe_details_layout)
+
+
+@dp.callback_query_handler(partial(is_valid_schema_for_callback, schema=DeleteRecipeCallbackData))
+async def delete_recipe(callback_query):
+    recipe_callback_data = DeleteRecipeCallbackData.parse_raw(callback_query.data)
+    await db.remove_recipe_by_id(callback_query.from_user.id, recipe_callback_data.id)
+    answer = RECIPE_DELETED_MESSAGE
+    await bot.edit_message_text(text=answer,
+                                chat_id=callback_query.from_user.id,
+                                message_id=callback_query.message.message_id,
+                                inline_message_id=callback_query.inline_message_id,
+                                parse_mode=ParseMode.MARKDOWN)

--- a/app/handlers/message_handlers.py
+++ b/app/handlers/message_handlers.py
@@ -1,0 +1,64 @@
+from aiogram.dispatcher.filters.state import State, StatesGroup
+from aiogram.types import ParseMode
+
+from app import db
+from app.exceptions import UserHasNoRecipesError
+from app.keyboards.markups import recipes_list_inline_keyboard_markup
+from app.data.messages_text import (WELCOME_MESSAGE, EMPTY_RECIPES_LIST_MESSAGE,
+                                    SHOWN_RECIPES_MESSAGE, WRITE_RECIPE_NAME_MESSAGE,
+                                    ADDED_RECIPE_MESSAGE, SINGLE_SHOWN_RECIPE_MESSAGE,
+                                    ALL_RECIPES_MARKED_AS_UNUSED_MESSAGE)
+from loader import dp, logger
+
+
+class AddNewRecipeStates(StatesGroup):
+    """Finite state machine for recipe addition processing"""
+    recipe_name = State()
+
+
+@dp.message_handler(commands=['start', 'help'])
+async def start(message):
+    welcome_message = WELCOME_MESSAGE
+    await message.answer(welcome_message)
+
+
+@dp.message_handler(commands=['list'])
+async def show_recipes_list(message):
+    recipes = await db.list_user_recipes(message.chat.id)
+    if not recipes:
+        await message.answer(text=EMPTY_RECIPES_LIST_MESSAGE)
+    else:
+        markup = recipes_list_inline_keyboard_markup(recipes)
+        await message.answer(text=SHOWN_RECIPES_MESSAGE, reply_markup=markup)
+
+
+@dp.message_handler(commands=['add'])
+async def add_recipe(message):
+    await AddNewRecipeStates.recipe_name.set()
+    await message.answer(WRITE_RECIPE_NAME_MESSAGE)
+
+
+@dp.message_handler(state=AddNewRecipeStates.recipe_name)
+async def process_recipe_name(message, state):
+    await db.add_recipe_by_name(message.chat.id, message.text)
+    await message.answer(f'{ADDED_RECIPE_MESSAGE}`{message.text}`', parse_mode=ParseMode.MARKDOWN)
+    await state.finish()
+
+
+@dp.message_handler(commands=['random'])
+async def take_random_recipe(message):
+    try:
+        recipe = await db.take_random_recipe(message.chat.id)
+    except UserHasNoRecipesError:
+        logger.exception(f"user {message.chat.id} called /random without recipes")
+        await message.answer(text=EMPTY_RECIPES_LIST_MESSAGE)
+    else:
+        text = f'{SINGLE_SHOWN_RECIPE_MESSAGE}' \
+               f'*{recipe.name}*'
+        await message.answer(text=text, parse_mode=ParseMode.MARKDOWN)
+
+
+@dp.message_handler(commands=['unuse_all'])
+async def unuse_all_recipes(message):
+    await db.unuse_all_recipes(message.chat.id)
+    await message.answer(ALL_RECIPES_MARKED_AS_UNUSED_MESSAGE)

--- a/app/keyboards/layouts.py
+++ b/app/keyboards/layouts.py
@@ -2,6 +2,9 @@ from aiogram.types import ParseMode
 
 from app.keyboards.markups import recipe_details_markup
 from app.recipe_shema import RecipeWithId
+from app.data.messages_text import (IS_USED_RECIPE_DETAILS_MESSAGE,
+                                    IS_UNUSED_RECIPE_DETAILS_MESSAGE,
+                                    SINGLE_SHOWN_RECIPE_MESSAGE)
 
 
 def create_recipe_details_layout(recipe: RecipeWithId) -> dict:
@@ -15,8 +18,8 @@ def create_recipe_details_layout(recipe: RecipeWithId) -> dict:
               `bot.send_message`, `message.answer`, `bot.edit_message_text` and etc.
     """
     markup = recipe_details_markup(recipe)
-    is_used_status_line = 'Использован \U0001F373' if recipe.is_used else '*Неиспользован*'
-    details_text = 'Рецепт:\n' \
+    is_used_status_line = IS_USED_RECIPE_DETAILS_MESSAGE if recipe.is_used else IS_UNUSED_RECIPE_DETAILS_MESSAGE
+    details_text = f'{SINGLE_SHOWN_RECIPE_MESSAGE}' \
                    f'*{recipe.name}*\n' \
-                   f'Статус: *{is_used_status_line}*'
+                   f'{is_used_status_line}'
     return dict(text=details_text, reply_markup=markup, parse_mode=ParseMode.MARKDOWN)

--- a/app/keyboards/markups.py
+++ b/app/keyboards/markups.py
@@ -7,6 +7,9 @@ from app.callback_data_schema import (DeleteRecipeCallbackData,
                                       UnuseRecipeCallbackData,
                                       UseRecipeCallbackData)
 from app.recipe_shema import RecipeWithId
+from app.data.messages_text import (MARK_AS_UNUSED_RECIPE_BUTTON_TEXT,
+                                    MARK_AS_USED_RECIPE_BUTTON_TEXT,
+                                    DELETE_RECIPE_BUTTON_TEXT)
 
 
 def create_inline_keyboard_button(
@@ -56,16 +59,16 @@ def recipe_details_markup(recipe: RecipeWithId) -> InlineKeyboardMarkup:
     buttons = []
     id_data = {'id': recipe.id}
     if recipe.is_used:
-        unuse_recipe_button = create_inline_keyboard_button('Пометить как неиспользованный',
+        unuse_recipe_button = create_inline_keyboard_button(MARK_AS_UNUSED_RECIPE_BUTTON_TEXT,
                                                             UnuseRecipeCallbackData,
                                                             id_data)
         buttons.append([unuse_recipe_button])
     else:
-        use_recipe_button = create_inline_keyboard_button('Использовать рецепт',
+        use_recipe_button = create_inline_keyboard_button(MARK_AS_USED_RECIPE_BUTTON_TEXT,
                                                           UseRecipeCallbackData,
                                                           id_data)
         buttons.append([use_recipe_button])
-    delete_button = create_inline_keyboard_button('Удалить', DeleteRecipeCallbackData, id_data)
+    delete_button = create_inline_keyboard_button(DELETE_RECIPE_BUTTON_TEXT, DeleteRecipeCallbackData, id_data)
     buttons.append([delete_button])
     markup = create_inline_markup_from_buttons(buttons)
     return markup

--- a/docker-compose-ecs.yml
+++ b/docker-compose-ecs.yml
@@ -19,7 +19,7 @@ services:
     restart: on-failure
     volumes:
       - ./logs:/app/logs
-    command: ["python", "server.py"]
+    command: ["python", "server.py", "-e", "webhook"]
     env_file: 
       - .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - .env
     volumes:
       - ./logs:/app/logs
-    command: ["python", "server.py"]
+    command: ["python", "server.py", "-e", "polling"]
     depends_on:
       - mongo
     links:

--- a/loader.py
+++ b/loader.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 
 from motor.motor_asyncio import (AsyncIOMotorClient,
                                  AsyncIOMotorDatabase)
@@ -7,10 +6,7 @@ from aiogram import Bot, Dispatcher
 from aiogram.contrib.fsm_storage.memory import MemoryStorage
 from loguru import logger
 
-from app.data.config import TG_TOKEN
-
-
-io_loop = asyncio.get_event_loop()
+from app.data.config import TG_TOKEN, MONGO_URI, MONGO_RECIPE_DB_NAME
 
 
 def _connect_to_db() -> AsyncIOMotorDatabase:
@@ -19,21 +15,15 @@ def _connect_to_db() -> AsyncIOMotorDatabase:
     Returns:
         AsyncIOMotorDatabase: Mongo database
     """
-    db_user = os.environ['MONGO_USER']
-    db_password = os.environ['MONGO_PASSWORD']
-    host = os.environ['MONGO_HOST']
-    port = os.environ['MONGO_PORT']
-    recipe_db_name = os.environ['MONGO_RECIPE_DB']
-
-    connection_string = f'mongodb://{db_user}:{db_password}@{host}:{port}'
-    client = AsyncIOMotorClient(connection_string, io_loop=io_loop)
+    client = AsyncIOMotorClient(MONGO_URI, io_loop=io_loop)
     client.get_io_loop = asyncio.get_running_loop
-    db = client[recipe_db_name]
+    db = client[MONGO_RECIPE_DB_NAME]
     return db
 
 
-db = _connect_to_db()
+io_loop = asyncio.get_event_loop()
 
+db_connection = _connect_to_db()
 
 bot = Bot(TG_TOKEN, loop=io_loop)
 storage = MemoryStorage()

--- a/loader.py
+++ b/loader.py
@@ -5,6 +5,7 @@ from motor.motor_asyncio import (AsyncIOMotorClient,
                                  AsyncIOMotorDatabase)
 from aiogram import Bot, Dispatcher
 from aiogram.contrib.fsm_storage.memory import MemoryStorage
+from loguru import logger
 
 from app.data.config import TG_TOKEN
 
@@ -37,3 +38,5 @@ db = _connect_to_db()
 bot = Bot(TG_TOKEN, loop=io_loop)
 storage = MemoryStorage()
 dp = Dispatcher(bot, storage=storage)
+
+logger.add("logs/recipe_bot.log", rotation="5 MB")

--- a/server.py
+++ b/server.py
@@ -1,194 +1,49 @@
-from functools import partial
 import ssl
+import argparse
 
 from aiogram import executor
-from aiogram.dispatcher.filters.state import State, StatesGroup
-from aiogram.types import ParseMode
-from loguru import logger
 
-from app import db
-from app.callback_data_schema import (DeleteRecipeCallbackData,
-                                      RecipeDetailsCallbackData,
-                                      UnuseRecipeCallbackData,
-                                      UseRecipeCallbackData,
-                                      is_valid_schema_for_callback)
 from app.data.config import (WEBAPP_HOST, WEBAPP_PORT,
                              WEBHOOK_PATH, WEBHOOK_URL, WEBHOOK_SSL_CERT,
                              WEBHOOK_SSL_PRIV)
-from app.exceptions import UserHasNoRecipesError, UserHasNoSelectedRecipeError
-from app.keyboards.layouts import create_recipe_details_layout
-from app.keyboards.markups import recipes_list_inline_keyboard_markup
-from loader import dp, bot
+from loader import bot, logger
+from app.handlers import dp
 
 
-logger.add("logs/recipe_bot.log", rotation="5 MB")
+parser = argparse.ArgumentParser(description='Start bot via polling or webhook')
+parser.add_argument('-e', '--executor-type', type=str,
+                    help='`polling` or `webhook`')
 
 
-
-class AddNewRecipeStates(StatesGroup):
-    """Finite state machine for recipe addition processing"""
-    recipe_name = State()
-
-
-@dp.message_handler(commands=['start', 'help'])
-async def start(message):
-    welcome_message = 'Привет!\n' \
-                      'Бот работает как мешок, в который можно поместить записки,' \
-                      ' перемешать и вытащить случайную.\n' \
-                      'Для себя я использую бота как мешок с блюдами. Когда' \
-                      ' не могу выбрать, что поесть - беру наугад.\n' \
-                      'Значок \U0001F373 означает, что обьект уже использован.\n' \
-                      'С проблемами и пожалениями обращайтесь к @kekusmekus.'
-    await message.answer(welcome_message)
+def start_polling():
+    logger.info("Bot starts with polling.")
+    executor.start_polling(dp, skip_updates=True)
 
 
-@dp.message_handler(commands=['list'])
-async def show_recipes_list(message):
-    recipes = await db.list_user_recipes(message.chat.id)
-    if not recipes:
-        await message.answer(text='Список рецептов пуст.')
-    else:
-        markup = recipes_list_inline_keyboard_markup(recipes)
-        text = 'Список рецептов:'
-        await message.answer(text=text, reply_markup=markup)
+def start_webhook():
+    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+    context.load_cert_chain(WEBHOOK_SSL_CERT, WEBHOOK_SSL_PRIV)
+    logger.info("Bot starts with webhook.")
+    executor.start_webhook(dispatcher=dp, webhook_path=WEBHOOK_PATH, on_startup=on_webhook_startup,
+                           skip_updates=True, host=WEBAPP_HOST, port=WEBAPP_PORT, ssl_context=context)
 
 
-@dp.message_handler(commands=['add'])
-async def add_recipe(message):
-    await AddNewRecipeStates.recipe_name.set()
-    await message.answer('Напишите название рецепта')
-
-
-@dp.message_handler(state=AddNewRecipeStates.recipe_name)
-async def process_recipe_name(message, state):
-    await db.add_recipe_by_name(message.chat.id, message.text)
-    await message.answer(f'Добавлен рецепт\n`{message.text}`', parse_mode=ParseMode.MARKDOWN)
-    await state.finish()
-
-
-@dp.message_handler(commands=['random'])
-async def take_random_recipe(message):
-    try:
-        recipe = await db.take_random_recipe(message.chat.id)
-    except UserHasNoRecipesError:
-        logger.exception(f"user {message.chat.id} called /random without recipes")
-        await message.answer(text='Список рецептов пуст. Чтобы добавить рецепт отправьте "/add"')
-    else:
-        text = 'Рецепт:\n' \
-            f'*{recipe.name}*'
-        await message.answer(text=text, parse_mode=ParseMode.MARKDOWN)
-
-
-@dp.message_handler(commands=['unuse_all'])
-async def unuse_all_recipes(message):
-    await db.unuse_all_recipes(message.chat.id)
-    await message.answer('Все рецепты помечены как неиспользованные.')
-
-
-@dp.callback_query_handler(partial(is_valid_schema_for_callback, schema=RecipeDetailsCallbackData))
-async def show_recipe_details(callback_query):
-    recipe_callback_data = RecipeDetailsCallbackData.parse_raw(callback_query.data)
-    # TODO: (1) (this is how identical fragments are marked)
-    # I don't know how to abstract this block.
-    # I don't want to check if recipe is exists each time.
-    # Because of performance and and that this situation is really an error.
-    # And I think return None by db method is bad idea because of poorly
-    # controlled behavior.
-    # If you know good resolution for this situation, please
-    # write an issue or do a pull request.
-    try:
-        recipe = await db.find_recipe_by_id(callback_query.from_user.id,
-                                            recipe_callback_data.id)
-    except UserHasNoSelectedRecipeError:
-        logger.exception(
-            f"user {callback_query.from_user.id} clicked on already"
-            "deleted recipe with id {recipe_callback_data.id}"
-            )
-        await callback_query.answer(text='Ошибка! Рецепт отсутствует.')
-        await callback_query.message.delete()
-    else:
-        recipe_details_layout = create_recipe_details_layout(recipe)
-        await bot.edit_message_text(chat_id=callback_query.from_user.id,
-                                    message_id=callback_query.message.message_id,
-                                    **recipe_details_layout)
-
-
-@dp.callback_query_handler(partial(is_valid_schema_for_callback, schema=UseRecipeCallbackData))
-async def use_recipe(callback_query):
-    recipe_callback_data = UseRecipeCallbackData.parse_raw(callback_query.data)
-    recipe_id = recipe_callback_data.id
-    # TODO: (1)
-    try:
-        recipe = await db.take_recipe_by_id(callback_query.from_user.id, recipe_id)
-    except UserHasNoSelectedRecipeError:
-        logger.exception(
-            f"user {callback_query.from_user.id} clicked on already"
-            "deleted recipe with id {recipe_callback_data.id}"
-            )
-        await callback_query.answer(text='Ошибка! Рецепт отсутствует.')
-        await callback_query.message.delete()
-    else:
-        recipe_details_layout = create_recipe_details_layout(recipe)
-        await bot.edit_message_text(chat_id=callback_query.from_user.id,
-                                    message_id=callback_query.message.message_id,
-                                    inline_message_id=callback_query.inline_message_id,
-                                    **recipe_details_layout)
-
-
-@dp.callback_query_handler(partial(is_valid_schema_for_callback, schema=UnuseRecipeCallbackData))
-async def unuse_recipe(callback_query):
-    recipe_callback_data = UnuseRecipeCallbackData.parse_raw(callback_query.data)
-    recipe_id = recipe_callback_data.id
-    # TODO: (1)
-    try:
-        recipe = await db.unuse_and_find_recipe_by_id(callback_query.from_user.id, recipe_id)
-    except UserHasNoSelectedRecipeError:
-        logger.exception(
-            f"user {callback_query.from_user.id} clicked on already"
-            "deleted recipe with id {recipe_callback_data.id}"
-            )
-        await callback_query.answer(text='Ошибка! Рецепт отсутствует.')
-        await callback_query.message.delete()
-    else:
-        recipe_details_layout = create_recipe_details_layout(recipe)
-        await bot.edit_message_text(chat_id=callback_query.from_user.id,
-                                    message_id=callback_query.message.message_id,
-                                    inline_message_id=callback_query.inline_message_id,
-                                    **recipe_details_layout)
-
-
-@dp.callback_query_handler(partial(is_valid_schema_for_callback, schema=DeleteRecipeCallbackData))
-async def delete_recipe(callback_query):
-    recipe_callback_data = DeleteRecipeCallbackData.parse_raw(callback_query.data)
-    await db.remove_recipe_by_id(callback_query.from_user.id, recipe_callback_data.id)
-    answer = 'Рецепт удален.'
-    await bot.edit_message_text(text=answer,
-                                chat_id=callback_query.from_user.id,
-                                message_id=callback_query.message.message_id,
-                                inline_message_id=callback_query.inline_message_id,
-                                parse_mode=ParseMode.MARKDOWN)
-
-
-async def on_startup(app):
-    # Get current webhook status
+async def on_webhook_startup(app):
     webhook = await bot.get_webhook_info()
 
-    # If URL is bad
     if webhook.url != WEBHOOK_URL:
-        # If URL doesnt match current - remove webhook
         if not webhook.url:
             await bot.delete_webhook()
 
-        # Set new URL for webhook
         await bot.set_webhook(WEBHOOK_URL, certificate=open(WEBHOOK_SSL_CERT, 'rb'))
 
 
 if __name__ == '__main__':
-    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-    context.load_cert_chain(WEBHOOK_SSL_CERT, WEBHOOK_SSL_PRIV)
-    executor.start_webhook(dispatcher=dp, webhook_path=WEBHOOK_PATH, on_startup=on_startup,
-                           skip_updates=True, host=WEBAPP_HOST, port=WEBAPP_PORT, ssl_context=context)
-
-# if __name__ == '__main__':
-#     executor.start_polling(dp, skip_updates=True)
-#     logger.info("Bot started with polling.")
+    args = parser.parse_args()
+    executor_type = args.executor_type
+    if executor_type == 'polling':
+        start_polling()
+    elif executor_type == 'webhook':
+        start_webhook()
+    else:
+        raise argparse.ArgumentError('Bad value for executor type argument')


### PR DESCRIPTION
* Call `python server.py` now has argument for choosing executor type.
    * `python server.py -e polling` or `python server.py -e webhook`
    * `docker-compose-ecs.yml` use start command `python server.py -e webhook`
    * `docker-compose.yml` use start command `python server.py -e polling`
* Handlers moved to `app/handlers`
* logger moved to `loader.py`
* bot messages to user moved to `app/data/messages_texts.py` constants